### PR TITLE
Unseals I18n class + subclass documentation for locales customizations re: #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,7 @@ I18n.SetLocale("fr-FR");
 System.Console.WriteLine(i18n.__("Hello"));
 // outputs: Bonjour
 ```
+
+## License
+
+[MIT](LICENSE.md) © [Cameron Manavian](https://github.com/camsjams)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # i18n-unity-csharp
 
-Lightweight internationalization for use with C#, uses common `__('...')` syntax.
+Lightweight internationalization for use with C#, uses common [`__('...')` gettext](https://www.gnu.org/software/gettext/manual/gettext.html) syntax.
 
 Created and used by [Moon Gate Labs](http://moongatelabs.com/)
 
 It allows developers to utilize multiple languages seamlessly within their Unity projects.
 
-It is also able to work outside of Unity projects as a standalone library!
+<del>It is also able to work outside of Unity projects as a standalone library!</del> See [#4](https://github.com/MoonGateLabs/i18n-unity-csharp/issues/4)
 
 ## Status
 
@@ -19,22 +19,47 @@ Beta - Version 0.9.4
 * [Unity](https://unity3d.com/)
 * [Unity SimpleJSON](http://wiki.unity3d.com/index.php/SimpleJSON)
 
-## Usage - setup and configuration
+## Usage - Setup and configuration
 
-###
+1. Copy `I18nUnity` folder to your Unity3D project's `Assets` folder (or anywhere else Unity can see it will work)
 
-Import `i18n-unity-csharp` into the class that you wish to utilize with:
+2. Create a `class` (ex: in `Assets/Scripts`) that will _subclass_ `I18n` so you can customize you language list:
 
 ```csharp
-using Mgl.Locale;
+// Replace MyApp with your own namespace
+namespace MyApp {
+  public class I18n : Mgl.I18n {
+    protected static readonly I18n instance = new I18n();
+
+    // Customize your languages here
+    protected static string[] locales = new string[] {
+      "en-US",
+      "fr-FR",
+      "es-ES",
+      "de-DE"
+    };
+
+    public static I18n Instance {
+      get {
+        return instance;
+      }
+    }
+  }
+}
 ```
 
-Create an instance of the class and be sure to only use it in methods after the Start() period occurs - do not call from within Awake():
+You can now use `I18n` by adding your namespace (in the following example, `MyApp`).
+
+```csharp
+using MyApp;
+```
+
+3. Create an instance of the class and be sure to only use it in methods after the `Start()` period occurs - do not call from within `Awake()`:
 
 ```csharp
 private I18n i18n = I18n.Instance;
 
-...
+// ...
 
 void Start()
 {
@@ -42,7 +67,7 @@ void Start()
 }
 ```
 
-Your translation files must be in JSON compliant format and be named according to their language and variant.
+4. Your translation files must be in JSON compliant format and be named according to their language and variant.
 
 ```
 [project-root]
@@ -54,6 +79,8 @@ Your translation files must be in JSON compliant format and be named according t
                 es-ES.json
                 fr-FR.json
 ```
+
+## Usage - Optional configuration
 
 You can configure a few different settings using `Configure()`:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # i18n-unity-csharp
+
 Lightweight internationalization for use with C#, uses common `__('...')` syntax.
 
 Created and used by [Moon Gate Labs](http://moongatelabs.com/)
@@ -8,9 +9,11 @@ It allows developers to utilize multiple languages seamlessly within their Unity
 It is also able to work outside of Unity projects as a standalone library!
 
 ## Status
+
 Beta - Version 0.9.4
 
 ## Platforms / Technologies
+
 * [C#](http://en.wikipedia.org/wiki/C_Sharp_programming_language)
 * [JSON](http://json.org/)
 * [Unity](https://unity3d.com/)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Beta - Version 0.9.4
 
 1. Copy `I18nUnity` folder to your Unity3D project's `Assets` folder (or anywhere else Unity can see it will work)
 
-2. Create a `class` (ex: in `Assets/Scripts`) that will _subclass_ `I18n` so you can customize you language list:
+2. Create your own `I18n` class (ex: in `Assets/Scripts`) that will _subclass_ `Mgl.I18n` so you can specify your own locales:
 
 ```csharp
 // Replace MyApp with your own namespace

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # i18n-unity-csharp
-Lightweight internationalization for use with C#, uses common __('...') syntax.
+Lightweight internationalization for use with C#, uses common `__('...')` syntax.
 
 Created and used by [Moon Gate Labs](http://moongatelabs.com/)
 
@@ -18,168 +18,192 @@ Beta - Version 0.9.4
 
 ## Usage - setup and configuration
 
+###
+
 Import `i18n-unity-csharp` into the class that you wish to utilize with:
 
-    using Mgl.Locale;
+```csharp
+using Mgl.Locale;
+```
 
 Create an instance of the class and be sure to only use it in methods after the Start() period occurs - do not call from within Awake():
 
-    private I18n i18n = I18n.Instance;
-    
-    ...
-    
-    void Start()
-    {
-			 string hW = i18n.__("Hello World!");
-    }
+```csharp
+private I18n i18n = I18n.Instance;
+
+...
+
+void Start()
+{
+    string hW = i18n.__("Hello World!");
+}
+```
 
 Your translation files must be in JSON compliant format and be named according to their language and variant.
 
-    [project-root]
-        |_ Assets
-            |_ Resources
-                |_ Locales
-                    en-GB.json
-                    en-US.json
-                    es-ES.json
-                    fr-FR.json
+```
+[project-root]
+    |_ Assets
+        |_ Resources
+            |_ Locales
+                en-GB.json
+                en-US.json
+                es-ES.json
+                fr-FR.json
+```
 
 You can configure a few different settings using `Configure()`:
 
-    I18n.Configure(
-        string localePath = null       // Unity location for translations defaults to 'Locales' inside of 'Assets/Resources/Locales/'
-        string defaultLocale = null    // language locale used, defaults to en-US
-        bool logMissing = true         // log missing translations
-    );
+```csharp
+I18n.Configure(
+    string localePath = null       // Unity location for translations defaults to 'Locales' inside of 'Assets/Resources/Locales/'
+    string defaultLocale = null    // language locale used, defaults to en-US
+    bool logMissing = true         // log missing translations
+);
+```
 
 You can change the path directly using the `SetPath()` function, although we recommend using the default path:
 
-    I18n.SetPath("Locales/");
+```csharp
+I18n.SetPath("Locales/");
+```
 
 You can also change the locale at any time using the `SetLocale()` function:
 
-    I18n.SetLocale("en-US");
+```csharp
+I18n.SetLocale("en-US");
+```
 
 ## Usage - Translation JSON format
 
 Some sample JSON:
 
-    {
-        "Hello": "Hello",
-        "Hello {0}, how are you today?": "Hello {0}, how are you today?",
-        "Combo: {0}x": "Combo {0}x",
-        "You have one cat": {
-            "zero": "You have no cats",
-            "one": "You have one cat",
-            "other": "You have a lot of cats!"
-        },
-        "You found {0} item": {
-            "zero": "No items found",
-            "one": "You found one item",
-            "other": "You found {0} items"
-        },
-        "{0} credits": {
-            "zero": "No credits",
-            "one": "{0} credit",
-            "other": "{0} credits"
-        },
-        "Score: {0} points": {
-            "zero": "nada",
-            "one": "Score: {0} point",
-            "other": "Score: {0} point"
-        },
-        "Level {1} time: {0}": "Level {1} time: {0}",
-        "Hit": {
-            "zero": "hit!",
-            "one": "-{0}",
-            "other": "-{0}"
-        },
-        "There is one monkey in the {1}": {
-            "zero": "There are no monkeys in the {1}.",
-            "one": "There is one monkey in the {1}.",
-            "other": "There are {0} monkeys in the {1}!"
-        }
+```json
+{
+    "Hello": "Hello",
+    "Hello {0}, how are you today?": "Hello {0}, how are you today?",
+    "Combo: {0}x": "Combo {0}x",
+    "You have one cat": {
+        "zero": "You have no cats",
+        "one": "You have one cat",
+        "other": "You have a lot of cats!"
+    },
+    "You found {0} item": {
+        "zero": "No items found",
+        "one": "You found one item",
+        "other": "You found {0} items"
+    },
+    "{0} credits": {
+        "zero": "No credits",
+        "one": "{0} credit",
+        "other": "{0} credits"
+    },
+    "Score: {0} points": {
+        "zero": "nada",
+        "one": "Score: {0} point",
+        "other": "Score: {0} point"
+    },
+    "Level {1} time: {0}": "Level {1} time: {0}",
+    "Hit": {
+        "zero": "hit!",
+        "one": "-{0}",
+        "other": "-{0}"
+    },
+    "There is one monkey in the {1}": {
+        "zero": "There are no monkeys in the {1}.",
+        "one": "There is one monkey in the {1}.",
+        "other": "There are {0} monkeys in the {1}!"
     }
-    
+}
+```
+
 ## Usage - Examples and configuration
 
 Here are some basic examples using the JSON above, you can also review the unit tests in `I18nTest` for more examples.
 
 Assuming you are using Unity - *although this works without Unity* as well!
-    
-    Text test = null;
-    test.text = i18n.__("Hello");
-    // puts: Hello
-    test.text = i18n.__("Combo: {0}x", 5);
-    // puts: Combo: 5x
+
+```csharp
+Text test = null;
+test.text = i18n.__("Hello");
+// puts: Hello
+test.text = i18n.__("Combo: {0}x", 5);
+// puts: Combo: 5x
+```
 
 Zero, one, or 'other' amount (greater than 1 or less than -1)
 
-    string message;
-    message = i18n.__("You have one cat", 0);
-    // puts: You have no cats
-    message = i18n.__("You have one cat", 1);
-    // puts: You have one cat
-    message = i18n.__("You have one cat", 45);
-    // puts: You have a lot of cats!
+```csharp
+string message;
+message = i18n.__("You have one cat", 0);
+// puts: You have no cats
+message = i18n.__("You have one cat", 1);
+// puts: You have one cat
+message = i18n.__("You have one cat", 45);
+// puts: You have a lot of cats!
+```
 
 Replacements using zero, one, or 'other' amount (greater than 1 or less than -1)
 
-    Text test = null;
-    test.text = i18n.__("{0} credits", 0);
-    // puts: No credits
-    test.text = i18n.__("{0} credits", 1);
-    // puts: 1 credit
-    test.text = i18n.__("{0} credits", 45);
-    // puts: 45 credits
-    test.text = i18n.__("{0} credits", 15.23);
-    // puts: 15.23 credits
-    test.text = i18n.__("{0} credits", 0.85);
-    // puts: 0.85 credits
-    
-    test.text = i18n.__("You found {0} item", 0);
-    // puts: No items found
-    test.text = i18n.__("You found {0} item", 1);
-    // puts: You found one item
-    test.text = i18n.__("You found {0} item", 10);
-    // puts: You found 10 items
-    
-    test.text = i18n.__("Score: {0} points", 0);
-    // puts: nada
-    test.text = i18n.__("Score: {0} points", 1);
-    // puts: Score: 1 point
-    test.text = i18n.__("Score: {0} points", 1000);
-    // puts: Score: 1000 points
-    test.text = i18n.__("Score: {0} points", -1);
-    // puts: Score: -1 point
-    test.text = i18n.__("Score: {0} points", -1000);
-    // puts: Score: -1000 points
+```csharp
+Text test = null;
+test.text = i18n.__("{0} credits", 0);
+// puts: No credits
+test.text = i18n.__("{0} credits", 1);
+// puts: 1 credit
+test.text = i18n.__("{0} credits", 45);
+// puts: 45 credits
+test.text = i18n.__("{0} credits", 15.23);
+// puts: 15.23 credits
+test.text = i18n.__("{0} credits", 0.85);
+// puts: 0.85 credits
 
+test.text = i18n.__("You found {0} item", 0);
+// puts: No items found
+test.text = i18n.__("You found {0} item", 1);
+// puts: You found one item
+test.text = i18n.__("You found {0} item", 10);
+// puts: You found 10 items
+
+test.text = i18n.__("Score: {0} points", 0);
+// puts: nada
+test.text = i18n.__("Score: {0} points", 1);
+// puts: Score: 1 point
+test.text = i18n.__("Score: {0} points", 1000);
+// puts: Score: 1000 points
+test.text = i18n.__("Score: {0} points", -1);
+// puts: Score: -1 point
+test.text = i18n.__("Score: {0} points", -1000);
+// puts: Score: -1000 points
+```
 
 String replacements
 
-    string message;
-    message = i18n.__("Hello {0}, how are you today?", "Jane");
-    // puts: Hello Jane, how are you today?
-    message= i18n.__("Level {1} time: {0}", '00:30:29", "The Cave Level");
-    // puts: Level The Cave Level time: 00:30:29
-
+```csharp
+string message;
+message = i18n.__("Hello {0}, how are you today?", "Jane");
+// puts: Hello Jane, how are you today?
+message= i18n.__("Level {1} time: {0}", "00:30:29", "The Cave Level");
+// puts: Level The Cave Level time: 00:30:29
+```
 
 String replacements and quantity checks
 
-    System.Console.WriteLine( i18n.__("There is one monkey in the {1}", 0, "tree"));
-    // outputs: There are no monkeys in the tree.
-    System.Console.WriteLine(i18n.__("There is one monkey in the {1}", 1, "tree"));
-    // outputs: There is one monkey in the tree.
-    System.Console.WriteLine(i18n.__("There is one monkey in the {1}", 27, "tree"));
-    // outputs: There are 27 monkeys in the tree!
-
+```csharp
+System.Console.WriteLine( i18n.__("There is one monkey in the {1}", 0, "tree"));
+// outputs: There are no monkeys in the tree.
+System.Console.WriteLine(i18n.__("There is one monkey in the {1}", 1, "tree"));
+// outputs: There is one monkey in the tree.
+System.Console.WriteLine(i18n.__("There is one monkey in the {1}", 27, "tree"));
+// outputs: There are 27 monkeys in the tree!
+```
 
 Change language
 
-    System.Console.WriteLine(i18n.__("Hello"));
-    // outputs: Hello
-    I18n.SetLocale("fr-FR");
-    System.Console.WriteLine(i18n.__("Hello"));
-    // outputs: Bonjour
-    
+```csharp
+System.Console.WriteLine(i18n.__("Hello"));
+// outputs: Hello
+I18n.SetLocale("fr-FR");
+System.Console.WriteLine(i18n.__("Hello"));
+// outputs: Bonjour
+```

--- a/src/I18nUnity/Mgl/I18n.cs
+++ b/src/I18nUnity/Mgl/I18n.cs
@@ -5,13 +5,13 @@ using System.Linq;
 
 namespace Mgl
 {
-    public sealed class I18n
+    public class I18n
     {
         private static JSONNode config = null;
 
-        private static readonly I18n instance = new I18n();
+        protected static readonly I18n instance = new I18n();
 
-        private static string[] locales = new string[] { "en-US", "fr-FR", "es-ES" };
+        protected static string[] locales = new string[] { "en-US", "fr-FR", "es-ES" };
 
         private static string _currentLocale = "en-US";
 
@@ -24,7 +24,7 @@ namespace Mgl
            
         }
 
-        private I18n()
+        protected I18n()
         {
         }
 


### PR DESCRIPTION
This closes #2
Includes #3 Thanks @jbroadway!

I also fixed a small documentation problem and added proper syntax
highlighting to ReadMe.

I've tested this and using it in a project this way :+1:

ReadMe can be previewed here:
https://github.com/GabLeRoux/i18n-unity-csharp/tree/feature/subclass-to-customize-locales