### PR TITLE
Make locales configurable

### DIFF
--- a/src/I18nUnity/Mgl/I18n.cs
+++ b/src/I18nUnity/Mgl/I18n.cs
@@ -7,7 +7,7 @@ namespace Mgl
 {
     public class I18n
     {
-		private static JSONNode translationData = null;
+        private static JSONNode translationData = null;
 
         protected static readonly I18n instance = new I18n();
 
@@ -58,15 +58,15 @@ namespace Mgl
 
         public static void SetLocale(string newLocale = null)
         {
-            Configure (_localePath, newLocale, _isLoggingMissing);
+            Configure (newLocale: newLocale);
         }
 
         public static void SetPath(string localePath = null)
         {
-            Configure (localePath, _currentLocale, _isLoggingMissing);
+            Configure (localePath: localePath);
         }
 
-        public static void Configure(string localePath = null, string newLocale = null, bool logMissing = true)
+        public static void Configure(string localePath = null, string newLocale = null, bool? logMissing = null, string[] locales = null)
         {
             if (localePath != null) {
                 _localePath = localePath;
@@ -74,7 +74,12 @@ namespace Mgl
             if (newLocale != null) {
                 _currentLocale = newLocale;
             }
-            _isLoggingMissing = logMissing;
+            if (logMissing.HasValue) {
+                _isLoggingMissing = logMissing.Value;
+            }
+            if (locales != null) {
+                I18n.locales = (string[])locales.Clone ();
+            }
             InitConfig();
         }
 

--- a/src/I18nUnity/Mgl/I18nTest.cs
+++ b/src/I18nUnity/Mgl/I18nTest.cs
@@ -16,7 +16,7 @@
         public void Init()
         {
             I18n i18n = I18n.Instance;
-            I18n.Configure("Locales/", "en-US");
+            I18n.Configure(localePath: "Locales/", newLocale: "en-US", logMissing: true, locales: new string[] { "en-US", "fr-FR", "es-ES" });
         }
 
 
@@ -43,6 +43,15 @@
 
             I18n.SetLocale("en-US");
             Assert.AreEqual("en-US", I18n.GetLocale());
+        }
+
+        [Test]
+        public void TestConfigureLocales()
+        {
+            I18n i18n = I18n.Instance;
+            I18n.Configure (newLocale: "de-DE", locales: new string[] { "en-US", "de-DE" });
+            Assert.AreEqual("de-DE", I18n.GetLocale());
+            Assert.AreEqual("Hallo", i18n.__ ("Hello"));
         }
 
         [Test]

--- a/src/I18nUnity/bin/Debug/Locales/de-DE.json
+++ b/src/I18nUnity/bin/Debug/Locales/de-DE.json
@@ -1,0 +1,3 @@
+{
+    "Hello": "Hallo"
+}


### PR DESCRIPTION
This pull request has 2 changes:

1. Add `locales` argument to `Configure()`
1. Change `logMissing` type from `bool` to `bool?` in order to skip `_isLoggingMissing` modification when `null` is given